### PR TITLE
Fetch also diet:vegan=limited venues from Overpass

### DIFF
--- a/refresh.py
+++ b/refresh.py
@@ -116,7 +116,7 @@ def get_data_osm():
 
     # Preparing the string for the Overpass request
     overpass_data_out =       '?data=[out:json];('
-    overpass_vegan_objects =  'node["diet:vegan"~"yes|only"];way["diet:vegan"~"yes|only"];'
+    overpass_vegan_objects =  'node["diet:vegan"~"yes|only|limited"];way["diet:vegan"~"yes|only|limited"];'
     overpass_vegetarian_objects = 'node["diet:vegetarian"~"yes|only"];way["diet:vegetarian"~"yes|only"];'
     overpass_out =            ');out+center;'
 


### PR DESCRIPTION
I noticed a mismatch between `write_data` which was checking for `diet:vegan=limited` and `get_data_osm` which was not querying for it.

After this change, 25 more venues are found.