### PR TITLE
Cache search results individually, without conflation

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -26,7 +26,7 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     caches.open(CACHE_NAME)
       .then(cache => {
-        return cache.match(event.request, {ignoreSearch: true})
+        return cache.match(event.request)
          .then(response => {
            var fetchPromise = fetch(event.request)
              .then(networkResponse => {


### PR DESCRIPTION
This seems to fix #81. If keeping the `ignoreSearch` option is important,
another solution might be to not cache the search results at all.