### PR TITLE
Add review link to popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ There are several ways to get involved:
 2. Report issues
 3. Help to translate (take [locales/en.json](locales/en.json) as template)
 4. Participate in development
+5. Write reviews for places on [https://lib.reviews/](lib.reviews)
 
 ## Keys
 

--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
         <p id="content-osm-text"></p>
         <h1 id="content-contribute-heading"></h1>
         <p id="content-contribute-text"></p>
+        <h1 id="content-reviews-heading"></h1>
+        <p id="content-reviews-text"></p>
         <h1 id="content-further-heading"></h1>
         <p id="content-further-text"></p>
       </div>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -97,6 +97,8 @@ function updateContent() {
   document.getElementById('content-osm-text').innerHTML = i18next.t('texts.content-osm-text');
   document.getElementById('content-contribute-heading').innerText = i18next.t('texts.content-contribute-heading');
   document.getElementById('content-contribute-text').innerHTML = i18next.t('texts.content-contribute-text');
+  document.getElementById('content-reviews-heading').innerText = i18next.t('texts.content-reviews-heading');
+  document.getElementById('content-reviews-text').innerHTML = i18next.t('texts.content-reviews-text');
   document.getElementById('content-further-heading').innerText = i18next.t('texts.content-further-heading');
   document.getElementById('content-further-text').innerHTML = i18next.t('texts.content-further-text');
 

--- a/js/veggiemap.js
+++ b/js/veggiemap.js
@@ -277,6 +277,22 @@ function calculateTooltip(layer) {
     return eSym + " " + eNam;
 }
 
+
+/**
+ * Check if there is an entry for a place (feature) on https://lib.reviews/.
+ * @param  {Object} feature
+ */
+function addLibReview(feature) {
+  const url = 'https://lib.reviews/api/thing?url=https://www.openstreetmap.org/' + feature.properties._type + '/' + feature.properties._id;
+  fetch(url)
+  .then(response => response.json())
+  .then(data => document.getElementById('libreviews').innerHTML = '<div class="popupflex-container"><div>📓</div><div><a href="https://lib.reviews/' + data.thing.urlID + '" target="_blank" rel="noopener noreferrer">' + i18next.t('words.review') + '</a></div>')
+  .catch(error => {
+    console.log("There is no review of this place or lib.reviews isn't available.");
+  });
+}
+
+
 // Calculate popup content for a given marker layer
 function calculatePopup(layer) {
     // Get the information
@@ -361,6 +377,10 @@ function calculatePopup(layer) {
     if(eWeb!=undefined){popupContent += "<div class='popupflex-container'><div>🌐</div><div><a href='" + eWeb + "' target='_blank' rel='noopener noreferrer'>" + eWeb.replace("https://", "") + "</a></div></div>"}
     if(eFac!=undefined){popupContent += "<div class='popupflex-container'><div>🇫</div><div><a href='" + eFac + "' target='_blank' rel='noopener noreferrer'>" + decodeURI(eFac).replace("https://", "") + "</a></div></div>"}
     if(eIns!=undefined){popupContent += "<div class='popupflex-container'><div>📸</div><div><a href='" + eIns + "' target='_blank' rel='noopener noreferrer'>" + eIns.replace("https://", "") + "</a></div></div>"}
+
+    // Add review entry from lib.reviews if exists
+    popupContent += "<div id='libreviews'></div>";
+    addLibReview(feature);
 
     return popupContent;
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -12,6 +12,8 @@
         "content-osm-text": "<a href='https://www.openstreetmap.org' target='_blank' rel='noopener noreferrer'>OpenStreetMap</a> ist eine freie Weltkarte und funktioniert so ähnlich wie Wikipedia. Jeder kann mitmachen und Informationen eintragen. Dadurch ist die Karte immer aktuell und voll von nützlichen Informationen. Wer Verbesserungsvorschläge hat oder Fehler in der Karte findet, kann diese einfach selbst eintragen oder verbessern.",
         "content-contribute-heading": "Informationen beitragen",
         "content-contribute-text": "Wenn du selbst Restaurants, Cafés, Eisdielen oder Imbissbuden kennst, die noch nicht in der Karte auftauchen, oder selbst eins betreibst, dann kannst du es einfach selbst hinzufügen. Dazu musst du den 'diet:vegan'- oder 'diet:vegetarian'-Tag bei deiner Location in OpenStreetMap hinzufügen. Eine Anleitung dazu gibt es <a href='how-to/tutorial_de.html' target='_blank' rel='noopener noreferrer'>hier</a>.",
+        "content-reviews-heading": "Rezensionen",
+        "content-reviews-text": "<a href='https://lib.reviews/' target='_blank' rel='noopener noreferrer'>lib.rewiews</a> ist eine freie und offene Plattform, um alles mögliche zu rezensieren. Falls es dort eine Rezension zu einem Ort gibt, zeigen wir einen Link dazu an.",
         "content-further-heading": "Sonstiges",
         "content-further-text": "Die Veggiekarte aktualisiert sich automatisch jede Stunde. Den Code findest du auf <a href='https://github.com/piratenpanda/veggiekarte' target='_blank' rel='noopener noreferrer'>GitHub</a>. Und als kleine Spielerei haben wir auch ein kleines Diagramm <a href='data_chart.html'>hier</a>.",
         "i18n_vegan_only": "alles vegan",
@@ -30,6 +32,7 @@
         "unknown": "unbekannt",
         "closed": "geschlossen",
         "public_holiday": "Feiertag",
+        "review": "Rezension",
         "school_holidays": "Ferien"
       },
       "leaflet": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,6 +12,8 @@
         "content-osm-text": "<a href='https://www.openstreetmap.org' target='_blank' rel='noopener noreferrer'>OpenStreetMap</a> is a free world map and works similarly to Wikipedia. Everyone can participate and enter information. This means that the map is full of useful information and updates continuously. Anyone who has suggestions for improvement or finds errors in the map can simply enter or fix data.",
         "content-contribute-heading": "Contribute information",
         "content-contribute-text": "If you yourself know restaurants, cafes, ice cream parlors or food kiosks that are not yet on the map, or run one yourself, then you can simply add them yourself. To do this, you have to mark the venue in OpenStreetMap with the 'diet:vegan' or 'diet:vegetarian' tag (\"Diet Types\"). Instructions are available <a href='how-to/tutorial_de.html' target='_blank' rel='noopener noreferrer'>here</a>.",
+        "content-reviews-heading": "Reviews",
+        "content-reviews-text": "<a href='https://lib.reviews/' target='_blank' rel='noopener noreferrer'>lib.rewiews</a> is a free and open platform for reviewing anything. If there is a review of a place there, we will show a link to it.",
         "content-further-heading": "Further",
         "content-further-text": "Veggiekarte is updated automatically every hour. You can find the code on <a href='https://github.com/piratenpanda/veggiekarte' target='_blank' rel='noopener noreferrer'>GitHub</a>. And as a little gimmick we also have a little diagram <a href='data_chart.html'>here</a>.",
         "i18n_vegan_only": "vegan only",
@@ -30,6 +32,7 @@
         "unknown": "unknown",
         "closed": "closed",
         "public_holiday": "holiday",
+        "review": "review",
         "school_holidays": "school holidays"
       },
       "leaflet": {

--- a/locales/eo.json
+++ b/locales/eo.json
@@ -9,9 +9,11 @@
         "content-welcome-heading": "Bonvenon",
         "content-welcome-text": "En veggiekarte.de vi povas trovi ĉiujn veganajn kaj vegetarajn restoraciojn, glaciaĵejojn, kafejojn ktp. registritajn en OpenStreetMap. Simple uzu la serĉkampon por serĉi vian lokon aŭ vian straton. Ĉiuj verdaj ikonoj estas lokoj kun veganaj ofertoj. Ikonoj neverdaj ofertas vegetarajn sed ne veganajn ofertoj.",
         "content-osm-heading": "Pri OpenStreetMap",
-        "content-osm-text": "<a href='https://www.openstreetmap.org' target='_blank' rel='noopener noreferrer'>OpenStreetMap</a> estas senpaga mondmapo kaj funkcias simile al Vikipedio. Ĉiu povas partopreni kaj enigi informojn. Tio signifas, ke la mapo estas ĉiam aktuala kaj plena de utilaj informoj. Ĉiu, kiu havas sugestojn pri plibonigo aŭ trovas erarojn en la mapo, povas simple enigi ilin aŭ plibonigi ilin.",
+        "content-osm-text": "<a href='https://www.openstreetmap.org' target='_blank' rel='noopener noreferrer'>OpenStreetMap</a> estas libera mondmapo kaj funkcias simile al Vikipedio. Ĉiu povas partopreni kaj enigi informojn. Tio signifas, ke la mapo estas ĉiam aktuala kaj plena de utilaj informoj. Ĉiu, kiu havas sugestojn pri plibonigo aŭ trovas erarojn en la mapo, povas simple enigi ilin aŭ plibonigi ilin.",
         "content-contribute-heading": "Kontribui informojn",
         "content-contribute-text": "Se vi scias pri restoracioj, kafejoj, glaciaĵejoj aŭ manĝejetoj, kiuj ankoraŭ ne estas en la mapo, aŭ mem posedas unu, tiam vi povas simple aldoni ĝin mem. Por fari tion, vi devas aldoni la etikedon 'dieto: vegano' aŭ 'dieto: vegetara' ĉe via loko en OpenStreetMap. Instrukcioj haveblas <a href='how-to/tutorial_de.html' target='_blank' rel='noopener noreferrer'>ĉi tie</a>.",
+        "content-reviews-heading": "Recenzoj",
+        "content-reviews-text": "<a href='https://lib.reviews/' target='_blank' rel='noopener noreferrer'>lib.rewiews</a> estas libera kaj malferma platformo por revizii ion ajn. Se estas recenzo pri loko tie, ni montros ligon al ĝi.",
         "content-further-heading": "Plue",
         "content-further-text": "Veggiekarte estas ĝisdatigita aŭtomate ĉiun horon. Vi povas trovi la kodon ĉe <a href='https://github.com/piratenpanda/veggiekarte' target='_blank' rel='noopener noreferrer'>GitHub</a>. Kaj kiel eta ludaĵo ni ankaŭ havas malgrandan diagramon <a href='data_chart.html'>ĉi tie</a>.",
         "i18n_vegan_only": "tute vegana",
@@ -30,6 +32,7 @@
         "unknown": "nekonata",
         "closed": "fermita",
         "public_holiday": "festotago",
+        "review": "recenzo",
         "school_holidays": "ferioj"
       },
       "leaflet": {

--- a/locales/fi.json
+++ b/locales/fi.json
@@ -12,6 +12,8 @@
         "content-osm-text": "<a href='https://www.openstreetmap.org' target='_blank' rel='noopener noreferrer'>OpenStreetMap</a> on vapaa maailmankartta ja toimii samaan tapaan kuin Wikipedia. Kaikki voivat osallistua ja syöttää tietoja. Tämä tarkoittaa, että kartta on täynnä hyödyllistä tietoa ja päivittyy koko ajan. Jokaisen, jolla on parannusehdotuksia tai joka löytää virheitä kartalta, tarvitsee vain itse lisätä tai korjata tietoja.",
         "content-contribute-heading": "Osallistu tiedonkeruuseen",
         "content-contribute-text": "Jos tiedät tai pidät itse ravintolaa, kahvilaa, jäätelöbaaria tai ruokakojua, joka ei vielä ole kartalla, voit lisätä sen itse. Tätä varten sinun tulee OpenStreetMapissa merkitä paikka tunnisteella 'diet:vegan' tai 'diet:vegetarian' (\"Erityisruokavaliot\"). Opastus on <a href='how-to/tutorial_de.html' target='_blank' rel='noopener noreferrer'>täällä</a>.",
+        "content-review-heading": "Arvostelu",
+        "content-review-text": "<a href='https://lib.reviews/' target='_blank' rel='noopener noreferrer'>lib.rewiews</a> on ilmainen ja avoin foorumi kaiken tarkastelemiseen. Jos siellä on arvostelu paikasta, näytämme linkin siihen.",
         "content-further-heading": "Lisäksi",
         "content-further-text": "Veggiekarte.de päivittyy automaattisesti tunnin välein. Lähdekoodi on saatavilla <a href='https://github.com/piratenpanda/veggiekarte' target='_blank' rel='noopener noreferrer'>GitHubista</a>. Ja pikku temppuna meillä on myös pikkuinen diagrammi <a href='data_chart.html'>täällä</a>.",
         "i18n_vegan_only": "kaikki vegaanista",
@@ -30,6 +32,7 @@
         "unknown": "ei tiedossa",
         "closed": "kiinni",
         "public_holiday": "pyhäpäivät",
+        "review": "arvostelu",
         "school_holidays": "lomakaudet"
       },
       "leaflet": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -12,6 +12,8 @@
         "content-osm-text": "<a href='https://www.openstreetmap.org' target='_blank' rel='noopener noreferrer'>OpenStreetMap</a> est une carte du monde gratuite et fonctionne de la même manière que Wikipedia. Tout le monde peut participer et saisir des informations. Cela signifie que la carte est toujours à jour et pleine d'informations utiles. Quiconque a des suggestions d'amélioration ou trouve des erreurs dans la carte peut simplement les saisir ou les améliorer.",
         "content-contribute-heading": "Contribuer des informations",
         "content-contribute-text": "Si vous connaissez vous-même des restaurants, des cafés, des glaciers ou des plats à emporter qui ne figurent pas encore au menu, ou si vous en gérez un vous-même, vous pouvez simplement l'ajouter vous-même. Pour ce faire, vous devez ajouter la balise «régime: végétalien» ou «régime: végétarien» à votre emplacement dans OpenStreetMap. Les instructions sont disponibles <a href='how-to/tutorial_de.html' target='_blank' rel='noopener noreferrer'>ici</a>.",
+        "content-reviews-heading": "Critiques",
+        "content-reviews-text": "<a href='https://lib.reviews/' target='_blank' rel='noopener noreferrer'>lib.rewiews</a> est une plate-forme gratuite et ouverte pour revoir n'importe quoi. S'il y a un avis sur un lieu là-bas, nous afficherons un lien vers celui-ci.",
         "content-further-heading": "Autres",
         "content-further-text": "Le menu végétarien est mis à jour automatiquement toutes les heures. Vous pouvez trouver le code sur <a href='https://github.com/piratenpanda/veggiekarte' target='_blank' rel='noopener noreferrer'>GitHub</a>. Et comme petit gadget, nous avons également un petit diagramme <a href='data_chart.html'>ici</a>.",
         "i18n_vegan_only": "tout est végétalien",
@@ -30,6 +32,7 @@
         "unknown": "indéterminé",
         "closed": "fermé",
         "public_holiday": "jour férié",
+        "review": "critiques",
         "school_holidays": "vacances scolaires"
       },
       "leaflet": {


### PR DESCRIPTION
[lib.reviews](https://lib.reviews/) is still a small, but free and open platform for reviewing everything. If there is a review for a place there, a link will now be displayed in the popup box. This is how it looks for the [SOJO in Tokio](https://veggiekarte.de/#18.00000/35.70829/139.72338):

![review](https://user-images.githubusercontent.com/35647502/108252554-11d2fc80-7159-11eb-94aa-7148453074de.png)

The link from this example leads to the page https://lib.reviews/sojo.