### PR TITLE
Set start date for historical data

### DIFF
--- a/generate_stats.py
+++ b/generate_stats.py
@@ -29,7 +29,7 @@ for key, filter_expression in FILTERS.items():
         "filter": filter_expression,
         "showMetadata": "true",
         "bboxes": "-180,-90,180,90",
-        "time": "//P1D",
+        "time": "2011-02-01//P1D",
     })
     response = json.loads(request.data.decode("utf-8"))
     for datapoint in response.get("result"):


### PR DESCRIPTION
Before February 2011, the diet tags were not used. We don't need to inflate the data file and the chart in `data_chart.html` unnecessarily.